### PR TITLE
fix: Vultr API expects the api_key in the URL, not in the request body

### DIFF
--- a/vultr/vultr.py
+++ b/vultr/vultr.py
@@ -863,11 +863,11 @@ class Vultr(object):
         if ipxe_chain_url is not None:
             params['ipxe_chain_url'] = ipxe_chain_url
         if isoid is not None:
-            params['isoid'] = isoid
+            params['ISOID'] = isoid
         if scriptid is not None:
-            params['scriptid'] = scriptid
+            params['SCRIPTID'] = scriptid
         if snapshotid is not None:
-            params['snapshotid'] = snapshotid
+            params['SNAPSHOTID'] = snapshotid
         if enable_ipv6 is not None:
             params['enable_ipv6'] = enable_ipv6
         if enable_private_network is not None:
@@ -875,11 +875,11 @@ class Vultr(object):
         if label is not None:
             params['label'] = label
         if sshkeyid is not None:
-            params['sshkeyid'] = sshkeyid
+            params['SSHKEYID'] = sshkeyid
         if auto_backups is not None:
             params['auto_backups'] = auto_backups
         if appid is not None:
-            params['appid'] = appid
+            params['APPID'] = appid
         return self.request('/v1/server/create', params, 'POST')
 
     def server_list_ipv4(self, subid):

--- a/vultr/vultr.py
+++ b/vultr/vultr.py
@@ -1312,12 +1312,13 @@ class Vultr(object):
         if not path.startswith('/'):
             path = '/' + path
         url = self.api_endpoint + path
-        params['api_key'] = self.api_key
 
         try:
             if method == 'POST':
+                url += "?api_key=" + self.api_key
                 resp = requests.post(url, data=params, timeout=60)
             elif method == 'GET':
+                params['api_key'] = self.api_key
                 resp = requests.get(url, params=params, timeout=60)
             else:
                 raise VultrError('Unsupported method %s' % method)


### PR DESCRIPTION
Without this fix, GET requests (like `servers_list`) work fine, but `server_create` gives me the following error on the same Vultr instance:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/aranhoide/src/lantern_aws/bin/vultr_util.py", line 26, in create
    sshkeyid=aranhoide_ssh_key_id)
  File "/usr/local/lib/python2.7/dist-packages/vultr/vultr.py", line 883, in server_create
    return self.request('/v1/server/create', params, 'POST')
  File "/usr/local/lib/python2.7/dist-packages/vultr/vultr.py", line 1335, in request
    key')
vultr.vultr.VultrError: Invalid or missing API key. Check that your API key is present and matches your assigned key
```
