### PR TITLE
Use unittest.skip to bypass authenticated tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/tests/test_vultr.py
+++ b/tests/test_vultr.py
@@ -22,26 +22,17 @@ class UnauthenticateTests(unittest.TestCase):
         response = self.vultr.app_list()
 
 
+@unittest.skipIf(not os.environ.get('VULTR_KEY'), 'Skipping AuthenticatedTests')
 class AuthenticatedTests(unittest.TestCase):
 
     def setUp(self):
         self.VULTR_KEY = os.environ.get('VULTR_KEY')
-
-        if self.VULTR_KEY is None:
-            warnings.warn('The VULTR_KEY environment variable is not ' +
-                          'set. AuthenticatedTests will be bypassed.',
-                          UserWarning)
-        else:
-            self.vultr = Vultr(self.VULTR_KEY)
+        self.vultr = Vultr(self.VULTR_KEY)
 
     def test_get_api_key(self):
-        if self.VULTR_KEY is None:
-            return
         response = self.vultr.iso_list()
 
     def test_post_api_key(self):
-        if self.VULTR_KEY is None:
-            return
         try:
             response = self.vultr.server_label_set('', '')
         except VultrError as e:
@@ -51,6 +42,9 @@ class AuthenticatedTests(unittest.TestCase):
                                   " \nInvalid server.  Check SUBID value and" +
                                   " ensure your API key matches the server's" +
                                   " account")
+
+    def test_account_info(self):
+        response = self.vultr.account_info()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Explicitly bypassing unit tests assertions based on a give value make it hard to tell whether the test was ran or not. TravisCI is always reporting it as succeeding. This option to skip seems more effective.
