### PR TITLE
Add python 3.5 support, drop python 3.2 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "nightly"
 install:
   - "pip install ."

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     license=read('LICENSE'),


### PR DESCRIPTION
This library is dependent on requests, requests doesn't support 3.2 due to issues with unicode. see: https://github.com/kennethreitz/requests/issues/3479 and related discussions.
