### PR TITLE
Add iso/create_from_url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ Python Vultr is supported on a volunteer basis.
 * def dns.records(self, domain, params=None):
 * def dns.update_record(self, domain, recordid, params=None):
 * def iso.list(self, params=None):
+* def iso.create_from_url(self, url, params=None)
 * def os.list(self, params=None):
 * def plans.list(self, params=None):
 * def regions.availability(self, dcid, params=None):

--- a/vultr/v1_iso.py
+++ b/vultr/v1_iso.py
@@ -1,5 +1,5 @@
 '''Partial class to handle Vultr ISO API calls'''
-from .utils import VultrBase
+from .utils import VultrBase, update_params
 
 
 class VultrISO(VultrBase):
@@ -16,3 +16,18 @@ class VultrISO(VultrBase):
         '''
         params = params if params else dict()
         return self.request('/v1/iso/list', params, 'GET')
+
+    def create_from_url(self, url, params=None):
+        ''' /vi/iso/create_from_url
+        POST - account
+        Create a new ISO image on the current account.
+        The ISO image will be downloaded from a given URL.
+        Download status can be checked with the v1/iso/list call.
+
+        Link: https://www.vultr.com/api/#iso_create_from_url
+        '''
+        params = update_params(params, {
+            'url': url,
+        })
+        return self.request('/v1/iso/create_from_url', params, 'POST')
+


### PR DESCRIPTION
See: https://www.vultr.com/api/#iso_create_from_url

I did write and run a test for this pull request but have not included it because:
- There is currently no function to delete ISOs so they must be manually removed after every test.
- Vultr only allows a maximum of two ISOs per account (unless you open a ticket to request more).